### PR TITLE
Replace non-breaking spaces with normal spaces

### DIFF
--- a/endianness.h
+++ b/endianness.h
@@ -51,11 +51,11 @@
       defined(bfin) || defined(BFIN)
 
       #define LITTLEENDIAN
-  #elif defined(__m68k__) || defined(M68000) || \
-        defined(__hppa__) || defined(__hppa) || defined(__HPPA__) || \
-        defined(__sparc__) || defined(__sparc) || \
+  #elif defined(__m68k__) || defined(M68000) || \
+        defined(__hppa__) || defined(__hppa) || defined(__HPPA__) || \
+        defined(__sparc__) || defined(__sparc) || \
         defined(__370__) || defined(__THW_370__) || \
-        defined(__s390__) || defined(__s390x__) || \
+        defined(__s390__) || defined(__s390x__) || \
         defined(__SYSC_ZARCH__)
 
       #define BIGENDIAN


### PR DESCRIPTION
uuid_v4 fails to compile for me with GCC 11.2.1 on Fedora 34 due to the presence of non-breaking spaces (a0 in hex):
```
../submodules/uuid_v4/endianness.h:54:48: error: extended character   is not valid in an identifier
   54 |   #elif defined(__m68k__) || defined(M68000) || \
      |                                                ^
../submodules/uuid_v4/endianness.h:55:69: error: extended character   is not valid in an identifier
   55 |         defined(__hppa__) || defined(__hppa) || defined(__HPPA__) || \
      |                                                                     ^
../submodules/uuid_v4/endianness.h:56:50: error: extended character   is not valid in an identifier
   56 |         defined(__sparc__) || defined(__sparc) || \
      |                                                  ^
../submodules/uuid_v4/endianness.h:58:51: error: extended character   is not valid in an identifier
   58 |         defined(__s390__) || defined(__s390x__) || \
```

This PR replaces these non-breaking spaces with normal spaces.