### PR TITLE
Better hashing function

### DIFF
--- a/uuid_v4.h
+++ b/uuid_v4.h
@@ -223,7 +223,7 @@ class UUID {
     size_t hash() const {
       const uint64_t a = *((uint64_t*)data);
       const uint64_t b = *((uint64_t*)&data[8]);
-      return a ^ b + 0x9e3779b9 + (a << 6) + (a >> 2);
+      return a ^ (b + 0x9e3779b9 + (a << 6) + (a >> 2));
     }
 
   private:

--- a/uuid_v4.h
+++ b/uuid_v4.h
@@ -221,7 +221,9 @@ class UUID {
     }
 
     size_t hash() const {
-      return *((uint64_t*)data) ^ *((uint64_t*)data+8);
+      const uint64_t a = *((uint64_t*)data);
+      const uint64_t b = *((uint64_t*)&data[8]);
+      return a ^ b + 0x9e3779b9 + (a << 6) + (a >> 2);
     }
 
   private:


### PR DESCRIPTION
I'm not 100% sure why it happened and I couldn't debug it properly.

When I used the UUID in an unordered map, it would sometimes not find the UUID even though it does exists in the map.
I feel like it has something to do with the hash function that this was using.

See this hash_combine proposal for reference to this hashing function:
 http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0814r2.pdf