### PR TITLE
Fix too large alignment value

### DIFF
--- a/uuid_v4.h
+++ b/uuid_v4.h
@@ -227,7 +227,7 @@ class UUID {
     }
 
   private:
-    alignas(128) uint8_t data[16];
+    alignas(16) uint8_t data[16];
 };
 
 /*


### PR DESCRIPTION
Problem lies in incorrect usage of `alignas` specifier: alignment represents the number of **bytes**, not bits (as defined [here](https://en.cppreference.com/w/cpp/language/object#Alignment)).
For this reason, UUID class occupies 8 times more space than actually needed (compared to 128 bits, or 16 bytes).