### PR TITLE
 Fix C2589 error: '(': illegal token on right side of '::'

### DIFF
--- a/uuid_v4.h
+++ b/uuid_v4.h
@@ -238,13 +238,13 @@ class UUID {
 template <typename RNG>
 class UUIDGenerator {
   public:
-    UUIDGenerator() : generator(new RNG(std::random_device()())), distribution(std::numeric_limits<uint64_t>::min(), std::numeric_limits<uint64_t>::max())
+    UUIDGenerator() : generator(new RNG(std::random_device()())), distribution((std::numeric_limits<uint64_t>::min)(), (std::numeric_limits<uint64_t>::max)())
     {}
 
-    UUIDGenerator(uint64_t seed) : generator(new RNG(seed)), distribution(std::numeric_limits<uint64_t>::min(), std::numeric_limits<uint64_t>::max())
+    UUIDGenerator(uint64_t seed) : generator(new RNG(seed)), distribution((std::numeric_limits<uint64_t>::min)(), (std::numeric_limits<uint64_t>::max)())
     {}
 
-    UUIDGenerator(RNG &gen) : generator(gen), distribution(std::numeric_limits<uint64_t>::min(), std::numeric_limits<uint64_t>::max())
+    UUIDGenerator(RNG& gen) : generator(gen), distribution((std::numeric_limits<uint64_t>::min)(), (std::numeric_limits<uint64_t>::max)())
     {}
 
     /* Generates a new UUID */


### PR DESCRIPTION
windows.h defines min and max as macros, which causes errors with std::numeric_limits<uint64_t>::min() and std::numeric_limits<uint64_t>::max(). Parenthesizing the function name fixes this.